### PR TITLE
update download release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Once the download has been completed, unpack the downloaded archive.
 The following command will automatically download and unpack the archive in the newly created `rabix` directory:
 
 ```sh
-wget https://github.com/rabix/bunny/releases/download/v1.0.0-rc5/rabix-1.0.0-rc5.tar.gz && tar -xvf rabix-1.0.0-rc5.tar.gz
+wget https://github.com/rabix/bunny/releases/download/v1.0.0-rc5/rabix-1.0.0-rc5.tar.gz -O rabix-1.0.0-rc5.tar.gz && tar -xvf rabix-1.0.0-rc5.tar.gz
 ```
 
 


### PR DESCRIPTION
The `wget` command downloaded the _tar_ file with filename depending on the redirect, therefore the subsequent _untar_ fails. By specifying the `-O` flag we can force a _filename_, so that the _untar_ command works.